### PR TITLE
Add NextRound UI

### DIFF
--- a/src/colony.cpp
+++ b/src/colony.cpp
@@ -496,6 +496,13 @@ void Colony::loadColony(string nazwa_plik){f_logisyka.load(nazwa_plik);}
 //Wywołanie funckji nextRound z Logistics
 int Colony::nextRound(){return f_logisyka.czyNextRound(buildings);}
 
+/**
+ * @brief Funkcja wywoływująca funkcję UIczyNextRound z Logistics
+ * 
+ * @return NextResult pakiet wyników z NextRound
+ */
+NextResult Colony::UInextRound(){return f_logisyka.UIczyNextRound(buildings);}
+
 //Sprawdzenie czy istnieje dany budynek
 bool Colony::czyBudynek(string bud)const{
     for(const auto &b:buildings){

--- a/src/colony.h
+++ b/src/colony.h
@@ -58,7 +58,7 @@ class Colony{
 
         //NEXT ROUND
         int nextRound();
-        
+        NextResult UInextRound(); 
 
         bool sprawdzLvlTerr();
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -137,6 +137,23 @@ struct BuildResult{
     string tekst;
 };
 
+/**
+ * @brief Struct do przekazywania wyników przejscia do kolejnej rundy
+ * 
+ */
+struct NextResult{
+    bool czy;
+    bool food;
+    bool energy;
+    bool terr;
+    string tekst;
+    double c_food;
+    double c_stone;
+    double c_titan;
+    double c_terr;
+};
+
+
 // ==========================================
 // FUNKCJE POMOCNICZE - UNIWERSALNE
 // ==========================================

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -499,6 +499,13 @@ void Game::commands(){
     cout<<endl;
 }
 
+/**
+ * @brief Funkcja wywoływująca funkcję NextRound z Colony
+ * 
+ * @return NextResult pakiet wyników z NextRound
+ */
+NextResult Game::UINextRound(){return kolonia.UInextRound();}
+
 // ==========================================
 // RZECZY Z PLIKAMI (LOAD)
 // ==========================================

--- a/src/game.h
+++ b/src/game.h
@@ -28,6 +28,7 @@ class Game{
         void commands();
         void build(BuildingInfo info);
         BuildResult UIbuild(BuildingInfo info, Graphics& grafika);
+        NextResult UINextRound();
 
         void UIrun();
         //PLIKI

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -6,8 +6,8 @@
 #include <optional>
 #include <map>
 
-Graphics::Graphics(unsigned int szer_,unsigned int wys_):szer(szer_),wys(wys_),window(sf::VideoMode({szer_, wys_}), "Colony ++"),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),ostatniWynik({false, ""}){}
-Graphics::Graphics():screenSize(sf::VideoMode::getDesktopMode()), window(screenSize, "Colony ++",sf::State::Fullscreen),szer(screenSize.size.x),wys(screenSize.size.y),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),ostatniWynik({false, ""}){}
+Graphics::Graphics(unsigned int szer_,unsigned int wys_):szer(szer_),wys(wys_),window(sf::VideoMode({szer_, wys_}), "Colony ++"),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),ostatniWynik({false, ""}),czyNextRound(false),czyNextRound1(false),nextWynik({false,false,false,false,"",0,0,0,0}){}
+Graphics::Graphics():screenSize(sf::VideoMode::getDesktopMode()), window(screenSize, "Colony ++",sf::State::Fullscreen),szer(screenSize.size.x),wys(screenSize.size.y),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),ostatniWynik({false, ""}),czyNextRound(false),czyNextRound1(false),nextWynik({false,false,false,false,"",0,0,0,0}){}
 
 /**
  * @brief Tymczasowe wyświeltanie głównego menu z przyciskami.
@@ -176,6 +176,11 @@ void Graphics::prntBudowanie(const Colony& kolonia,const map<string, BuildingInf
     ImGui::End();
 }
 
+/**
+ * @brief Funkcja wyświetlająca wyniki budowania budynku
+ * 
+ * @param gra 
+ */
 void Graphics::prntBudowanieWyniki(Game& gra){
 
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
@@ -211,9 +216,6 @@ void Graphics::prntBudowanieWyniki(Game& gra){
 
 }
 
-void Graphics::BudowanieWyniki(const BuildingInfo info,Game& gra){
-
-}
 
 /**
  * @brief Funkcja wyswietlajaca informacje o dostepnych budynkach do zbudowania z danej kategorii.
@@ -335,6 +337,178 @@ void Graphics::prntBuildCategory(const string& cat, const Colony& kolonia, const
         cout<<RED<<BOLD<<"Nie ma takiej kategorii!!"<<RESET<<endl;
         return;
     }
+}
+
+/**
+ * @brief Wyświetlanie przycisku przejscia do kolejnej rundy
+ * 
+ */
+void Graphics::prntNextRoundButton(){
+
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImVec2 window_pos = ImVec2(viewport->WorkPos.x + viewport->WorkSize.x - 10, viewport->WorkPos.y + 10);
+
+    ImGui::SetNextWindowPos(window_pos, ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+
+    if (ImGui::Begin("PrzyciskTuryFloating", nullptr,  ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground)) {
+        ImGui::SetWindowFontScale(3.0f);
+        if (ImGui::ArrowButton("##NextTurn", ImGuiDir_Right)) {
+            czyNextRound=true;
+        }
+        if (ImGui::IsItemHovered()) {
+                    ImGui::BeginTooltip(); 
+                    
+                    ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Kliknięcie spowoduje przejście do kolejnej rundy!");
+
+                    ImGui::EndTooltip(); 
+                }
+    }
+    ImGui::End();
+}
+
+/**
+ * @brief Funkcja wyświetlająca okno z 
+ * 
+ * @param kolonia wskaźnik do koloniii
+ * @param bazaDanych wskaźnik do bazy danych 
+ * @param gra wskaznik do klasy Game
+ */
+void Graphics::prntCzyNextRound(const Colony& kolonia,const map<string, BuildingInfo>& bazaDanych,Game& gra){
+
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(350, 150)); 
+    ImGui::Begin("Koniec Tury", nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
+    
+    ImGui::Dummy(ImVec2(0.0f, 10.0f));
+
+    std::string pyt = "Czy na pewno chcesz zakonczyc ture?";
+    float textWidth = ImGui::CalcTextSize(pyt.c_str()).x;
+    ImGui::SetCursorPosX((350.0f - textWidth) * 0.5f); 
+    ImGui::Text("%s", pyt.c_str());
+
+    ImGui::Dummy(ImVec2(0.0f, 20.0f)); 
+    ImGui::Separator();
+    ImGui::Dummy(ImVec2(0.0f, 5.0f));
+
+    float buttonWidth = 100.0f;
+    float spaceBetween = 40.0f;
+    float buttonsStartX = (350.0f - (2 * buttonWidth + spaceBetween)) * 0.5f;
+
+    ImGui::SetCursorPosX(buttonsStartX);
+
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.1f, 0.6f, 0.1f, 1.0f));        // Tło
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.8f, 0.2f, 1.0f)); // Najechanie
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.5f, 0.1f, 1.0f));  // Kliknięcie
+    if (ImGui::Button("TAK", ImVec2(buttonWidth, 30))) {
+        
+        nextWynik=gra.UINextRound();  // dodac dzialanie itp
+        czyNextRound1 = true;
+        czyNextRound = false;
+    }
+    ImGui::PopStyleColor(3); 
+
+    ImGui::SameLine(0, spaceBetween); 
+
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.7f, 0.1f, 0.1f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.9f, 0.2f, 0.2f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.6f, 0.1f, 0.1f, 1.0f));
+    if (ImGui::Button("NIE", ImVec2(buttonWidth, 30))) {
+        czyNextRound = false;
+    }
+    ImGui::PopStyleColor(3);
+
+    ImGui::End();
+}
+
+
+/**
+ * @brief Funkcja wyświetlająca okno z wynikiem kolejnej rundy
+ * 
+ * @param kolonia wskaźnik do koloniii
+ * @param bazaDanych wskaźnik do bazy danych 
+ * @param gra wskaznik do klasy Game
+ */
+void Graphics::prntNextRound(const Colony& kolonia, const map<string, BuildingInfo>& bazaDanych, Game& gra) {
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::Begin("Raport z kolonii", &czyNextRound1, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings);
+
+    // Brak jedzenia!
+    if (!nextWynik.food) {
+        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "KATASTROFA: KOLONIA UMARŁA Z GŁODU!");
+        ImGui::Separator();
+        ImGui::Text("Zabrakło jedzenia dla Twoich mieszkańców.");
+        
+        ImGui::Dummy(ImVec2(0.0f, 10.0f));
+        if (ImGui::Button("Zakończ grę", ImVec2(120, 30))) {
+            window.close(); 
+        }
+    } 
+    else {
+        
+        if (!nextWynik.energy) {
+            ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.0f, 1.0f), "OSTRZEŻENIE: BLACKOUT!");
+            ImGui::Separator();
+            ImGui::TextWrapped("Z powodu braku prądu produkcja stanęła w miejscu! Maszyny nie pracują.");
+            ImGui::Dummy(ImVec2(0.0f, 5.0f));
+        } else {
+            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "PODSUMOWANIE TURY:");
+            ImGui::Separator();
+        }
+
+        double zjedzone = kolonia.getReqFood(); 
+        double bilansJedzenia = nextWynik.c_food - zjedzone;
+
+        ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.8f, 1.0f), "Gospodarka żywnościowa:");
+        
+        
+        ImGui::Bullet(); ImGui::Text("Wyprodukowano:");
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%.0f", nextWynik.c_food);
+        
+        
+        ImGui::Bullet(); ImGui::Text("Zjedzono:");
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "-%.0f", zjedzone);
+        
+       
+        if (bilansJedzenia >= 0) {
+            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "  -> Bilans: +%.0f", bilansJedzenia);
+        } else {
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "  -> Bilans: %.0f (Zapasy maleją!)", bilansJedzenia);
+        }
+
+        ImGui::Dummy(ImVec2(0.0f, 5.0f));
+
+        ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.8f, 1.0f), "Wydobycie i nauka:");
+        
+        
+        ImGui::Bullet(); ImGui::Text("Kamień:");
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "+%.0f", nextWynik.c_stone);
+        
+       
+        ImGui::Bullet(); ImGui::Text("Tytan:");
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.4f, 0.8f, 1.0f, 1.0f), "+%.0f", nextWynik.c_titan);
+        
+        ImGui::Bullet(); ImGui::Text("Terraformacja:");
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.9f, 0.3f, 1.0f, 1.0f), "+%.0f", nextWynik.c_terr);
+
+        if (nextWynik.terr) {
+            ImGui::Dummy(ImVec2(0.0f, 10.0f));
+            ImGui::TextColored(ImVec4(0.2f, 0.8f, 1.0f, 1.0f), "AWANS TERRAFORMACJI!");
+            ImGui::Text("Odblokowano nowe technologie.");
+        }
+
+        ImGui::Dummy(ImVec2(0.0f, 15.0f));
+        ImGui::Separator();
+        
+        float buttonWidth = 120.0f;
+        ImGui::SetCursorPosX((ImGui::GetWindowWidth() - buttonWidth) * 0.5f);
+        if (ImGui::Button("Dalej", ImVec2(buttonWidth, 30))) {
+            czyNextRound1 = false; 
+        }
+    }
+
+    ImGui::End();
 }
 
 /**
@@ -466,6 +640,7 @@ void Graphics::prntAll(const Colony& kolonia,const map<string, BuildingInfo>& ba
        
         prntMenu();
         prntStatystyki(kolonia);
+        prntNextRoundButton();
 
         if(czyhelp){
             prntPomoc();
@@ -483,6 +658,12 @@ void Graphics::prntAll(const Colony& kolonia,const map<string, BuildingInfo>& ba
         }
         if(czyBudowanieWyniki){
             prntBudowanieWyniki(gra);
+        }
+        if(czyNextRound){
+            prntCzyNextRound(kolonia, bazaDanych,gra);
+        }
+        if(czyNextRound1){
+            prntNextRound(kolonia, bazaDanych,gra);
         }
         
         

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -30,15 +30,16 @@ class Graphics{
         bool czyBudowanie;
         bool czyBudowanieCategory;
         bool czyBudowanieWyniki;
+        bool czyNextRound;
+        bool czyNextRound1;
         string wybranaKategoriaBudowa;
         BuildResult ostatniWynik;
+        NextResult nextWynik;
     public:
 
         Graphics();
         Graphics(unsigned int szer_,unsigned int wys_);
         ~Graphics(){};
-
-        void BudowanieWyniki(const BuildingInfo info,Game& gra);
 
         void prntAll(const Colony& kolonia,const map<string, BuildingInfo>& bazaDanych, Game& gra);
         void prntMenu();
@@ -48,6 +49,10 @@ class Graphics{
         void prntBudowanie(const Colony& kolonia,const map<string, BuildingInfo>& bazaDanych,Game& gra);
         void prntBudowanieWyniki(Game& gra);
         void prntBuildCategory(const string& cat,const Colony& kolonia, const map<string, BuildingInfo>& bazaDanych,Game& gra);
-};
+        void prntNextRoundButton();
+        void prntCzyNextRound(const Colony& kolonia,const map<string, BuildingInfo>& bazaDanych,Game& gra);
+        void prntNextRound(const Colony& kolonia,const map<string, BuildingInfo>& bazaDanych,Game& gra);
+    
+    };
 
 #endif

--- a/src/logistics.cpp
+++ b/src/logistics.cpp
@@ -62,6 +62,56 @@ int Logistics::czyNextRound(const vector<unique_ptr<Building>>& budynki){
         return 0;
     }
 }
+
+
+/**
+ * @brief Funkcja sprawdzajaca czy sie udalo przejsc do kolejnej rundy
+ * 
+ * @param budynki Wektor zbudowanych budynków
+ * @return NextResult NextResult pakiet wyników z NextRound
+ */
+NextResult Logistics::UIczyNextRound(const vector<unique_ptr<Building>>& budynki){
+    // string decyzja;
+    // cout<<YELLOW<<">>Czy na pewno chcesz przejsc do kolejnej tury? (y / n)"<<RESET<<endl;
+    // cin>>decyzja;
+    // if(decyzja=="y"||decyzja=="yes"||decyzja=="tak"||decyzja=="t"){
+    //     cout<<YELLOW<<">>Rozpoczynanie procedury przejscia do kolejnej rundy..."<<RESET<<endl;
+    //     cout<<endl;
+
+        NextResult odp=UInextRound(budynki);//wywolywanie funkcji sprawdzajacej zaleznosci
+        if(odp.czy){
+            // cout<<GREEN<<BOLD<<"Udalo sie przejsc do kolejnej rundy!"<<RESET<<endl;
+            tura++;
+            ruch=0;
+            // cout<<endl;
+            // if(czyNext==1){
+            //     return 2;
+            // }else{
+            //     return 1;
+            // }
+        }
+    //     else if(food==0){
+    //         cout<<RED<<"KOLONIA UMARLA, Z POWODU BRAKU JEDZENIA!!"<<RESET<<endl;
+
+    //         return -1;
+    //     } else if(genEnergy<reqEnergy){
+    //         cout<<GREEN<<BOLD<<"Udalo sie przejsc do kolejnej rundy!"<<RED<<" Ale..."<<RESET<<endl;
+    //         cout<<RED<<BOLD<<"Z powod braku energii zaden z budynkow nie wykonal pracy!"<<RESET<<endl;
+    //         tura++;
+    //         ruch=0;
+    //         cout<<endl;
+    //         return 1;
+    //     } else{
+    //         return 0;
+    //     }
+    // }else{
+    //     cout<<YELLOW<<"Anulowano przejscie do kolejnej rundy."<<RESET<<endl;
+    //     return 0;
+    // }
+    return odp;
+}
+
+
 //FUNKCJA SPRAWDZAJACA PARAMETRY PRZY NEXT ROUND
 int Logistics::nextRound(const vector<unique_ptr<Building>>& budynki){
         if((food-reqFood)>=0){//Czy jest wystarczajaca liczba jedzenia?
@@ -147,6 +197,108 @@ int Logistics::nextRound(const vector<unique_ptr<Building>>& budynki){
             cout<<endl;
             return -1;
         }
+}
+
+
+/**
+ * @brief 
+ * 
+ * @param budynki wektor zbudowanych budynków
+ * @return NextResult paczka z wynikami przejścia do kolejnej rundy
+ */
+NextResult Logistics::UInextRound(const vector<unique_ptr<Building>>& budynki){
+    NextResult odp = {false,false,false,false,"",0,0,0,0};    
+    if((food-reqFood)>=0){//Czy jest wystarczajaca liczba jedzenia?
+            // cout<<GREEN<<"Ilosc jedzenia:"<<BOLD<< "ZGODNA"<<RESET<<endl;
+            // cout<<endl;
+
+            odp.food=true;
+            odp.czy=true;
+            food-=reqFood;
+            
+            if(genEnergy>=reqEnergy){//Czy jest wystarczajaca liczba produkowanego pradu?
+                // cout<<GREEN<<"Ilosc energii:"<<BOLD<< "ZGODNA"<<RESET<<endl;
+                // cout<<endl;
+                odp.energy=true;
+
+                //Sprawdzanie dzialania wszystkich budynkow
+                // cout<<YELLOW<<">>Sprawdzanie produkcji budynkow:..."<<RESET<<endl;
+                // cout<<endl;
+                
+                double c_food=0;
+                double c_stone=0;
+                double c_titan=0;
+                double c_terr=0;
+                int new_lvl=0;
+
+                
+                for(const auto& b: budynki){//Przejscie po kazdym zbudowanym budynku
+                    double c=0;
+                    c=b->work();//wywolanie funkcji work() na kazdym z budynkow
+                    switch(b->getTyp()){//w zaleznosci od klasy, zwrocona wartosc jset przypisywana do czegos innego
+                        case TypBudynku::FARM:
+                            c_food+=c;
+                            break;
+                        case TypBudynku::PRODUCER:{
+                            Producer* p = static_cast<Producer*>(b.get());
+                            c_stone += c;
+                            c_titan += p->getGenTitan(); //FIXME dodac jakas pair czy cos
+                            break;
+                        }
+                        case TypBudynku::TERR:{
+                            c_terr+=c;
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                }
+
+                // cout<<endl;
+                wsp_terr+=c_terr;
+                if(sprawdzLvlTerr()){//Sprawdzenie czy nie nastapilo osiagniecie kolejnego lvl
+                    odp.terr=true;
+                }
+
+                //Wyswietlenie zaktualizowanych rzeczy po nextRound
+                odp.c_food=c_food;
+                odp.c_stone=c_stone;
+                odp.c_titan=c_titan;
+                odp.c_terr=c_terr;
+
+                // prntRound(c_food,c_stone,c_titan,c_terr,new_lvl);
+                
+                //Dodanie wyprodukowanych surowcow do zmiennej
+                food+=c_food;
+                stone+=c_stone;
+                titan+=c_titan;
+                // cout<<endl;
+
+
+            }else{//BRAK ENERGII - budynki nie pracuja
+                
+
+                // cout<<RED<<"Ilosc energii:"<<BOLD<< "BRAK"<<RESET<<endl;
+                // cout<<RED<<BOLD<<"Niewystarczajaca ilosc energi!!"<<RESET<<endl;
+                // cout<<endl;
+
+                if((food-reqFood)>=0){
+                    // cout<<GREEN<<"Ilosc jedzenia:"<<BOLD<< "ZGODNA"<<RESET<<endl;
+                    // cout<<endl;
+                    odp.food=true;
+                }
+            }
+        }else{//BRAK JEDZENIA - KONIEC GRY
+            if(genEnergy>=reqEnergy){
+            odp.energy=true;
+            }
+
+            // cout<<RED<<"Ilosc jedzenia:"<<BOLD<< "BRAK"<<RESET<<endl;
+            // cout<<RED<<BOLD<<"Brak jedzenia!!"<<RESET<<endl;
+            food=0;
+            // cout<<endl;
+        }
+    return odp;
 }
 
 //SPRAWDZANIE POZIOMU TERRAFORMACJI

--- a/src/logistics.h
+++ b/src/logistics.h
@@ -45,7 +45,9 @@ class Logistics{
 
         //NEXT ROUND
         int czyNextRound(const vector<unique_ptr<Building>>& budynki);
+        NextResult UIczyNextRound(const vector<unique_ptr<Building>>& budynki);
         int nextRound(const vector<unique_ptr<Building>>& budynki);
+        NextResult UInextRound(const vector<unique_ptr<Building>>& budynki);
         bool sprawdzLvlTerr();
 
         //BUDOWANIE


### PR DESCRIPTION
### ADDED
- Struktura NextResult: Wprowadzono strukturę `NextResult` w `enums.h` (pola: success, flagi food/energy/terr, message oraz zmiany zasobów).
- Elementy UI: Rozbudowano klasę `Graphics` o interfejs nowej tury: pływający przycisk NextRound, okno potwierdzenia oraz okno raportu/wyników (`prntNextRoundButton`, `prntCzyNextRound`, `prntNextRound`).
- Stan grafiki: Dodano zmienne stanu do klasy `Graphics` (`czyNextRound`, `czyNextRound1`, `nextWynik`) wraz z ich inicjalizacją w konstruktorach.

### CHANGED
- Logika nowej tury: Spięto przepływ nowej tury wywoływany z poziomu UI.
- `Colony::UInextRound` i `Game::UINextRound` przekazują teraz żądania UI do warstwy `Logistics`.
- `Logistics::UIczyNextRound` i `Logistics::UInextRound` przetwarzają wyniki nowej tury (sprawdzanie jedzenia/energii, agregacja produkcji, testy terraformowania) i zwracają `NextResult`.
- Integracja UI: Podpięto nowe wywołania UI do głównej metody `prntAll`.
- Pliki nagłówkowe: Zaktualizowano odpowiednie nagłówki.

### FIXED
- Czyszczenie kodu: Usunięto nieużywany `BudowanieWyniki`.