### PR TITLE
Cleaning int przed czyszczeniem

### DIFF
--- a/src/building.cpp
+++ b/src/building.cpp
@@ -14,7 +14,7 @@ int Building::next_id=1;
 // ==========================================
 
 Building:: Building():kosztEnergii(0),kosztKamien(0),kosztTytan(0),type(TypBudynku::NIEZNANY),name("Budynek"),id(next_id++),workers(0),residents(0){}
-Building:: Building(string n,TypBudynku t, double kE,double kK, double kT,int w):kosztEnergii(kE),kosztKamien(kK),kosztTytan(kT),type(t),name(n),id(next_id++),workers(w), residents(0){}
+Building:: Building(string n,TypBudynku t, int kE, int kK, int kT,int w):kosztEnergii(kE),kosztKamien(kK),kosztTytan(kT),type(t),name(n),id(next_id++),workers(w), residents(0){}
 
 // ==========================================
 // VIRTUALNE
@@ -26,7 +26,7 @@ void Building:: prnt(int il)const{}
 void Building:: UIprnt(int il)const{}
 
 //WYKONYWANIE PRACY PRZEZ DANY BUDYNEK PODCZAS nextRound
-double Building:: work(){return 0;}
+int Building:: work(){return 0;}
 
 //ZAPISYWANIE DANYCH O BUDYNKU DO PLIKU
 void Building::save(ofstream& plik)const{
@@ -53,6 +53,6 @@ string Building:: getName()const {return name;}
 TypBudynku Building::getTyp() const {return type;}
 int Building::getResidents() const{return residents;}
 int Building::getDemandWorkers()const {return workers;}
-double Building::getReqEnergy() const{return kosztEnergii;}
-double Building::getKosztKamien() const{return kosztKamien;}
-double Building::getKosztTytan() const{return kosztTytan;}
+int Building::getReqEnergy() const{return kosztEnergii;}
+int Building::getKosztKamien() const{return kosztKamien;}
+int Building::getKosztTytan() const{return kosztTytan;}

--- a/src/building.h
+++ b/src/building.h
@@ -20,9 +20,9 @@ class Building{
         int id;
         static int next_id;
 
-        double kosztEnergii;
-        double kosztKamien;
-        double kosztTytan;
+        int kosztEnergii;
+        int kosztKamien;
+        int kosztTytan;
         
         int workers;
         int residents;
@@ -30,13 +30,13 @@ class Building{
     public:
         //KONSTRUKTORY
         Building();
-        Building(string n,TypBudynku t, double kE,double kK, double kT,int w);
+        Building(string n,TypBudynku t, int kE,int kK, int kT,int w);
         virtual ~Building(){};
 
         //VIRTUAL
         virtual void prnt(int il) const;
         virtual void save(ofstream& plik) const;
-        virtual double work();
+        virtual int work();
         /**
          * @brief Funkcja wyświetlająca dane o budynku
          * 
@@ -55,9 +55,9 @@ class Building{
         int getDemandWorkers() const;
         TypBudynku getTyp() const;
         int getResidents() const;
-        double getReqEnergy() const;
-        double getKosztKamien() const;
-        double getKosztTytan() const;
+        int getReqEnergy() const;
+        int getKosztKamien() const;
+        int getKosztTytan() const;
         
 };
 

--- a/src/colony.cpp
+++ b/src/colony.cpp
@@ -257,10 +257,10 @@ BuildResult Colony::UIczyStac(const unique_ptr<Building> &b)const{
         wynik.czy=true;
     }else{
         if(b->getKosztKamien()>f_logisyka.getStone()){
-            // wynik+="Brakuje "+to_string((int)(b->getKosztKamien()-f_logisyka.getStone()))+" kamienia!";
+            // wynik+="Brakuje "+to_string((b->getKosztKamien()-f_logisyka.getStone()))+" kamienia!";
             wynik.kamien=b->getKosztKamien()-f_logisyka.getStone();
         }else if(b->getKosztTytan()>f_logisyka.getTitan()){
-            // wynik+="Brakuje "+to_string((int)(b->getKosztTytan()-f_logisyka.getTitan()))+" tytanu!";
+            // wynik+="Brakuje "+to_string((b->getKosztTytan()-f_logisyka.getTitan()))+" tytanu!";
             wynik.tytan=b->getKosztTytan()-f_logisyka.getTitan();
         }
     }
@@ -377,24 +377,24 @@ DestroyResult Colony::UIzburzBudynek(string nazwa){
         // cout<<YELLOW<<">>Potwierdz wpisujac y, albo anuluj n."<<RESET<<endl;
         // cin>>dec;
         // if(dec=="y"||dec=="yes"||dec=="tak"||dec=="t"){
-            if(buildings[nr]->getTyp()==TypBudynku::HOUSING){
-                if(f_logisyka.getAWorkers()-buildings[nr]->getResidents()<f_logisyka.getDWorkers()){ //Sprawdzenie czy aby na pewno mozna usunac dany budynek - nie moze brakowac pracownikow!
-                    // cout<<"Niemozliwe jest zburzenie budynku: "<<buildings[nr]->getName()<<", poniewaz bedzei wtedy brakowalo "<<(f_logisyka.getDWorkers()-f_logisyka.getAWorkers()+buildings[nr]->getResidents())<<" pracownikow."<<endl;
-                    wynik.brakLudzi=f_logisyka.getDWorkers()-f_logisyka.getAWorkers()+buildings[nr]->getResidents();
-                }
-            }else{//Wszystko pasuje, wiec mozna zburzyc
-                // cout<<YELLOW<<">>Budynek "<<buildings[nr]->getName()<<" zostal wyburzony."<<RESET<<endl;
+        if(buildings[nr]->getTyp()==TypBudynku::HOUSING){
+            if(f_logisyka.getAWorkers()-buildings[nr]->getResidents()<f_logisyka.getDWorkers()){ //Sprawdzenie czy aby na pewno mozna usunac dany budynek - nie moze brakowac pracownikow!
+                // cout<<"Niemozliwe jest zburzenie budynku: "<<buildings[nr]->getName()<<", poniewaz bedzei wtedy brakowalo "<<(f_logisyka.getDWorkers()-f_logisyka.getAWorkers()+buildings[nr]->getResidents())<<" pracownikow."<<endl;
+                wynik.brakLudzi=f_logisyka.getDWorkers()-f_logisyka.getAWorkers()+buildings[nr]->getResidents();
+                return wynik;
+            }else{
                 wynik.czy=true;
-                if(static_cast<int>(buildings[nr]->getTyp())==static_cast<int>(TypBudynku::HOUSING)){
-                    f_logisyka.setAWorkers(-buildings[nr]->getResidents());
-                }
-                wynik.sur=f_logisyka.UIupdateZburzBudynek(buildings[nr].get());
-                buildings.erase(buildings.begin()+nr);
             }
-        // }else{
-        //     cout<<YELLOW<<"Anulowano wyburzanie budynku."<<RESET<<endl;
-        // }
-            
+        } else{
+            wynik.czy=true;
+        }
+        if(wynik.czy){
+            if(static_cast<int>(buildings[nr]->getTyp())==static_cast<int>(TypBudynku::HOUSING)){
+                f_logisyka.setAWorkers(-buildings[nr]->getResidents());
+            }
+            wynik.sur=f_logisyka.UIupdateZburzBudynek(buildings[nr].get());
+            buildings.erase(buildings.begin()+nr);  
+        }
     }else{
         cout<<RED<<"Blad: Nie ma budynku o takiej nazwie: "<<BOLD<<nazwa<<endl;
         cout<<endl;
@@ -448,7 +448,7 @@ void Colony::loadBuildings(string nazwa_plik) {
         //Parametry
         int w_type, w_id, w, maxSaved = 0;
         string w_n;
-        double kE,kT,kK;
+        int kE,kT,kK;
         //Format linii w pliku: TypBudynku Nazwa ID KosztEnergii KosztKamienia KosztTytanu Pracownicy ParametrySpecjalne
         //Przejscie przez plik, linijka po linijce
         while (plik >> w_type >> w_n >> w_id >> kE>>kK>>kT >> w) {
@@ -463,7 +463,7 @@ void Colony::loadBuildings(string nazwa_plik) {
 
                 case TypBudynku::ENERGY: {
                     //Dodatkowe parametry
-                    double e;
+                    int e;
                     plik >> e;
                     
                     auto energia = make_unique<Energy>(w_n, kE,kK,kT, e, w);
@@ -476,7 +476,7 @@ void Colony::loadBuildings(string nazwa_plik) {
 
                 case TypBudynku::FARM: {
                     //Dodatkowe parametry
-                    double f;
+                    int f;
                     int tim,ct;
                     plik >> f>>tim>>ct;
                 
@@ -501,7 +501,7 @@ void Colony::loadBuildings(string nazwa_plik) {
                 }
                 case TypBudynku::PRODUCER: {
                     //Dodatkowe parametry
-                    double s, ti;
+                    int s, ti;
                     plik >> s>>ti;
                 
                     auto producer = make_unique<Producer>(w_n, kE,kK,kT, s, w,ti);
@@ -513,7 +513,7 @@ void Colony::loadBuildings(string nazwa_plik) {
                 }
                 case TypBudynku::TERR: {
                     //Dodatkowe parametry
-                    double te;
+                    int te;
                     plik >> te;
                 
                     auto terr = make_unique<Terr>(w_n, kE,kK,kT, te, w);
@@ -605,9 +605,9 @@ int Colony::getIlosc(string name)const{//Zwracanie ilosci budynku o danej nazwie
 
 string Colony::getNazwa() const{return f_logisyka.getNazwa();}
 int Colony::getTura() const{return f_logisyka.getTura();}
-double Colony::getReqEnergy() const{return f_logisyka.getReqEnergy();}
-double Colony::getGenEnergy() const{return f_logisyka.getGenEnergy();}
-double Colony::getReqFood() const{return f_logisyka.getReqFood();}
-double Colony::getFood() const{return f_logisyka.getFood();}
+int Colony::getReqEnergy() const{return f_logisyka.getReqEnergy();}
+int Colony::getGenEnergy() const{return f_logisyka.getGenEnergy();}
+int Colony::getReqFood() const{return f_logisyka.getReqFood();}
+int Colony::getFood() const{return f_logisyka.getFood();}
 int Colony::getStone() const{return f_logisyka.getStone();}
 int Colony::getTitan() const{return f_logisyka.getTitan();}

--- a/src/colony.h
+++ b/src/colony.h
@@ -90,10 +90,10 @@ class Colony{
   
         string getNazwa() const;
         int getTura() const;
-        double getReqEnergy() const;
-        double getGenEnergy() const;
-        double getReqFood() const;
-        double getFood() const;
+        int getReqEnergy() const;
+        int getGenEnergy() const;
+        int getReqFood() const;
+        int getFood() const;
         int getStone() const;
         int getTitan() const;
 };

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -10,7 +10,7 @@ using namespace std;
 // ==========================================
 
 Energy:: Energy():Building("XXX",TypBudynku::ENERGY,0,0,0,0),enGen(0){}
-Energy::Energy(string n, double kE,double kK, double kT, double e,int w):Building(n,TypBudynku::ENERGY,kE,kK,kT,w),enGen(e){}
+Energy::Energy(string n, int kE,int kK, int kT, int e,int w):Building(n,TypBudynku::ENERGY,kE,kK,kT,w),enGen(e){}
 
 // ==========================================
 // OVERRIDE
@@ -29,5 +29,5 @@ void Energy::save(ofstream& plik)const{
     plik<<" "<<enGen<<" "<<endl;
 }
 
-double Energy::getEnergy() const{return enGen;}
+int Energy::getEnergy() const{return enGen;}
 

--- a/src/energy.h
+++ b/src/energy.h
@@ -14,12 +14,12 @@ using namespace std;
  */
 class Energy: public Building{
     private:
-        double enGen;
+        int enGen;
 
     public:
         //KONSTRUKTOR
         Energy();
-        Energy(string n, double kE,double kK, double kT, double e,int w);
+        Energy(string n, int kE,int kK, int kT, int e,int w);
         ~Energy(){};
 
         //OVERRIDE
@@ -28,7 +28,7 @@ class Energy: public Building{
         void save(ofstream& plik) const override;
 
         //GETTERY
-        double getEnergy() const;
+        int getEnergy() const;
         
 };
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -110,22 +110,22 @@ enum class TypBudynku {
  * 
  */
 struct BuildingInfo {
-    string nazwa;
-    string type;
+    string nazwa="";
+    string type="";
     
     // Koszty
-    double kKamien;
-    double kTytan;
-    double reqEnergy;
-    int workers;      
+    int kKamien=0;
+    int kTytan=0;
+    int reqEnergy=0;
+    int workers=0;      
     
     // Produkcja
-    double genKamien;
-    double genTytan;  
-    double genInne;  
-    double lvlTerr;
-    int x;     
-    string opis;
+    int genKamien=0;
+    int genTytan=0;  
+    int genInne=0;  
+    int lvlTerr=0;
+    int x=0;     
+    string opis="";
 };
 
 /**
@@ -133,20 +133,23 @@ struct BuildingInfo {
  * 
  */
 struct BuildResult{
-    bool czy;
-    int kamien;
-    int tytan;
-    int workers;
+    bool czy=false;
+    int kamien=0;
+    int tytan=0;
+    int workers=0;
     string nazwa;
-    int act_ruch;
-    bool ruch;
+    int act_ruch=0;
+    bool ruch=false;
 };
-
+/**
+ * @brief Struct do przekazywania wyników burzenia.
+ * 
+ */
 struct DestroyResult{
-    bool czy;
-    int brakLudzi;
-    string nazwa;
-    pair <float,float> sur;
+    bool czy=false;
+    int brakLudzi=0;
+    string nazwa="";
+    pair <int,int> sur={0,0};
 };
 
 /**
@@ -154,15 +157,15 @@ struct DestroyResult{
  * 
  */
 struct NextResult{
-    bool czy;
-    bool food;
-    bool energy;
-    bool terr;
-    string tekst;
-    double c_food;
-    double c_stone;
-    double c_titan;
-    double c_terr;
+    bool czy=false;
+    bool food=false;
+    bool energy=false;
+    bool terr=false;
+    string tekst="";
+    int c_food=0;
+    int c_stone=0;
+    int c_titan=0;
+    int c_terr=0;
 };
 
 

--- a/src/farm.cpp
+++ b/src/farm.cpp
@@ -10,7 +10,7 @@ using namespace std;
 // ==========================================
 
 Farm:: Farm():Building("XXX",TypBudynku::FARM,0,0,0,0),foodGen(0),time(0),curr_time(0){}
-Farm::Farm(string n, double kE,double kK, double kT, double f,int w,int tim,int ct):Building(n,TypBudynku::FARM,kE,kK,kT,w),foodGen(f),time(tim),curr_time(ct){}
+Farm::Farm(string n, int kE,int kK, int kT, int f,int w,int tim,int ct):Building(n,TypBudynku::FARM,kE,kK,kT,w),foodGen(f),time(tim),curr_time(ct){}
 
 // ==========================================
 // OVERRIDE
@@ -30,7 +30,7 @@ void Farm::save(ofstream& plik)const{
     plik<<" "<<foodGen<<" "<<time<<" "<<curr_time<<endl; 
 }
 
-double Farm::work(){// Przy pracy Farm, jest dodatkowo sprawdzany czas pracy
+int Farm::work(){// Przy pracy Farm, jest dodatkowo sprawdzany czas pracy
     curr_time++; //Kazdy Farm produkuje z inna predkoscia (musza urosnac rzeczy)
     if(curr_time==time){//Jak mija konkretny czas - liczba tur - to dopiero wtedy produkuje jedzenie
         curr_time=0;

--- a/src/farm.h
+++ b/src/farm.h
@@ -13,18 +13,18 @@ using namespace std;
  */
 class Farm: public Building{
     private:
-        double foodGen;
+        int foodGen;
         int time;
         int curr_time;
 
     public:
         //KONSTRUKTOR
         Farm();
-        Farm(string n, double kE,double kK, double kT, double f,int w,int tim,int ct);
+        Farm(string n, int kE,int kK, int kT, int f,int w,int tim,int ct);
         ~Farm(){};
         
         //OVERRIDE
-        double work() override;
+        int work() override;
         void prnt(int il) const override;
         void UIprnt(int il) const override;
         void save(ofstream& plik) const override;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -545,7 +545,7 @@ void Game::loadGameData(){ //Wczytywanie danych o budynkach - tylko na poczatku 
     }
 
     string n, type, opis;
-    double kK, kT, kE, gk, gt, gi; 
+    int kK, kT, kE, gk, gt, gi; 
     int w, x,lt;
 
     while(plik>>n>>type>>kK>>kT>>kE>>w>>gk>>gt>>gi>>x>>lt>>opis){

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -7,8 +7,8 @@
 #include <map>
 #include <cfloat>
 
-Graphics::Graphics(unsigned int szer_,unsigned int wys_):szer(szer_),wys(wys_),window(sf::VideoMode({szer_, wys_}), "Colony ++"),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),ostatniWynik({false, 0,0,0,"",0,false}),czyNextRound(false),czyNextRound1(false),nextWynik({false,false,false,false,"",0,0,0,0}),czyWyburzanie(false),czyWyburzanie1(false),destroyWynik({false,0,"",{0,0}}){}
-Graphics::Graphics():screenSize(sf::VideoMode::getDesktopMode()), window(screenSize, "Colony ++",sf::State::Fullscreen),szer(screenSize.size.x),wys(screenSize.size.y),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),ostatniWynik({false, 0,0,0,"",0,false}),czyNextRound(false),czyNextRound1(false),nextWynik({false,false,false,false,"",0,0,0,0}),czyWyburzanie(false),czyWyburzanie1(false),destroyWynik({false,0,"",{0,0}}){}
+Graphics::Graphics(unsigned int szer_,unsigned int wys_):szer(szer_),wys(wys_),window(sf::VideoMode({szer_, wys_}), "Colony ++"),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),czyNextRound(false),czyNextRound1(false),czyWyburzanie(false),czyWyburzanie1(false){}
+Graphics::Graphics():screenSize(sf::VideoMode::getDesktopMode()), window(screenSize, "Colony ++",sf::State::Fullscreen),szer(screenSize.size.x),wys(screenSize.size.y),czyhelp(false),czyBudynki(false),czyBudowanie(false),wybranaKategoriaBudowa(""),czyBudowanieCategory(false),czyBudowanieWyniki(false),czyNextRound(false),czyNextRound1(false),czyWyburzanie(false),czyWyburzanie1(false){}
 
 /**
  * @brief Tymczasowe wyświeltanie głównego menu z przyciskami.
@@ -103,15 +103,15 @@ void Graphics::prntStatystykiToolTop(const Colony& kolonia, map<string,int>& lic
             }
         }
 
-        ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "PRODUKCJA: %d", (int)kolonia.getGenEnergy());
+        ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "PRODUKCJA: %d", kolonia.getGenEnergy());
         for (const auto& wpis : gen) ImGui::BulletText("%s (x%d): +%d", wpis.nazwa.c_str(), wpis.ilo, wpis.gen);
         
         ImGui::Separator();
-        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "ZAPOTRZEBOWANIE: %d", (int)kolonia.getReqEnergy());
+        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "ZAPOTRZEBOWANIE: %d", kolonia.getReqEnergy());
         for (const auto& wpis : straty) ImGui::BulletText("%s (x%d): -%d", wpis.nazwa.c_str(), wpis.ilo, wpis.dem);
         
         ImGui::Separator();
-        int suma = (int)kolonia.getGenEnergy() - (int)kolonia.getReqEnergy();
+        int suma = kolonia.getGenEnergy() - kolonia.getReqEnergy();
         ImGui::TextColored(suma >= 0 ? ImVec4(0.2f, 1.0f, 0.2f, 1.0f) : ImVec4(1.0f, 0.2f, 0.2f, 1.0f), "BILANS: %d", suma);
     }
     
@@ -157,7 +157,7 @@ void Graphics::prntStatystykiToolTop(const Colony& kolonia, map<string,int>& lic
     
     else if (cat == "jedzenie") {
         CenterTitle("Zywnosc", ImVec4(0.6f, 1.0f, 0.2f, 1.0f)); 
-        int suma=-20;
+        int suma=0;
         for (const auto& [nazwa, ilosc] : licznik) {
             string nazwa_ = nazwa;
             for (auto &c : nazwa_) c = tolower(c);
@@ -170,30 +170,30 @@ void Graphics::prntStatystykiToolTop(const Colony& kolonia, map<string,int>& lic
                 wynik.gen = info.genInne * ilosc;
                 wynik.dem = info.x;
                 wynik.ilo = ilosc;
-                suma+=wynik.gen/info.x;
+                suma+=(wynik.gen-1+info.x)/info.x;
                 gen.push_back(wynik);
             }
             if (info.type == "HOUSING") {
                 ResInfo wynik;
                 wynik.nazwa = cleanString(info.nazwa);
                 wynik.gen = 0;
-                wynik.dem = (2 * info.genInne) * ilosc;
+                wynik.dem = 2 * info.genInne * ilosc;
                 wynik.ilo = ilosc;
                 straty.push_back(wynik);
             }
         }
 
-        ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "PRODUKCJA: %d", suma); // FIXME: wstaw sumę produkcji
+        ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "PRODUKCJA: %d", suma);
         for (const auto& wpis : gen) ImGui::BulletText("%s (x%d): +%d co %d tur", wpis.nazwa.c_str(), wpis.ilo, wpis.gen,wpis.dem);//wpis.dem to co ile tur!
         
         ImGui::Separator();
-        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "ZAPOTRZEBOWANIE: %d", (int)kolonia.getReqFood());
+        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "ZAPOTRZEBOWANIE: %d", kolonia.getReqFood());
         ImGui::BulletText("Baza: -20");
         for (const auto& wpis : straty) ImGui::BulletText("%s (x%d): -%d", wpis.nazwa.c_str(), wpis.ilo, wpis.dem);
         
         ImGui::Separator();
-        int suma_ = suma - (int)kolonia.getReqFood();
-        ImGui::TextColored(suma_ >= 0 ? ImVec4(0.2f, 1.0f, 0.2f, 1.0f) : ImVec4(1.0f, 0.2f, 0.2f, 1.0f), "BILANS: %d", suma);
+        int suma_ = suma - kolonia.getReqFood();
+        ImGui::TextColored(suma_ >= 0 ? ImVec4(0.2f, 1.0f, 0.2f, 1.0f) : ImVec4(1.0f, 0.2f, 0.2f, 1.0f), "BILANS: %d", suma_);
     }
     
     else if (cat == "kamien") {
@@ -318,9 +318,9 @@ void Graphics::prntStatystyki(const Colony& kolonia,  const map<string, Building
         }
         ImGui::SameLine();
         if (kolonia.getReqEnergy() > kolonia.getGenEnergy()) {
-            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%.0f/%.0f", kolonia.getGenEnergy(), kolonia.getReqEnergy()); // Czerwony
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%d/%d", kolonia.getGenEnergy(), kolonia.getReqEnergy()); // Czerwony
         } else {
-            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "%.0f/%.0f", kolonia.getGenEnergy(), kolonia.getReqEnergy()); // Zielony
+            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "%d/%d", kolonia.getGenEnergy(), kolonia.getReqEnergy()); // Zielony
         }
 
 
@@ -352,11 +352,11 @@ void Graphics::prntStatystyki(const Colony& kolonia,  const map<string, Building
         }
         suma-=kolonia.getReqFood();
         if (kolonia.getFood() > 2 * kolonia.getReqFood()) {
-            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "%.0f (%d)", kolonia.getFood(), suma); // Zielony
+            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "%d (%d)", kolonia.getFood(), suma); // Zielony
         } else if (kolonia.getFood() >= kolonia.getReqFood()) {
-            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "%.0f (%d)", kolonia.getFood(), suma); // Żółty 
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "%d (%d)", kolonia.getFood(), suma); // Żółty 
         } else {
-            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%.0f (%d)", kolonia.getFood(), suma); // Czerwony
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%d (%d)", kolonia.getFood(), suma); // Czerwony
         }
         ImGui::SameLine(0.0f, 40.0f); 
 
@@ -421,7 +421,7 @@ void Graphics::prntBudynki(const Colony& kolonia,const map<string, BuildingInfo>
             if(czyWyburzanie){ImGui::TableSetupColumn("Akcja");}
             ImGui::TableHeadersRow();
             for (const auto& [nazwa, ilosc] : licznik) {
-                if(czyWyburzanie){ImGui::PushID(i);}
+                ImGui::PushID(i);
                 string nazwa_ = cleanString(nazwa);
                 ImGui::TableNextRow();
                 
@@ -447,16 +447,16 @@ void Graphics::prntBudynki(const Colony& kolonia,const map<string, BuildingInfo>
                     if (ImGui::Button("Zburz", ImVec2(80, 0))) {
                         destroyWynik=gra.UIZburz(nazwa);
                         czyWyburzanie1 = true;
-                        czyWyburzanie=true;
+                        czyWyburzanie=false;
 
                     }
                     ImGui::PopStyleColor(2);
                 }
 
-                if(czyWyburzanie){
-                    ImGui::PopID();
-                    i++;
-                }
+                
+                ImGui::PopID();
+                i++;
+                
                 
             }
             ImGui::EndTable();
@@ -504,12 +504,12 @@ void Graphics::prntWyburz() {
 
             if (destroyWynik.sur.first > 0) {
                 ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.6f, 0.6f, 0.6f, 1.0f)); 
-                ImGui::BulletText("Kamien: %g", destroyWynik.sur.first);
+                ImGui::BulletText("Kamien: %d", destroyWynik.sur.first);
                 ImGui::PopStyleColor();
             }
             if (destroyWynik.sur.second > 0) {
                 ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 0.7f, 1.0f, 1.0f)); 
-                ImGui::BulletText("Tytan: %g", destroyWynik.sur.second);
+                ImGui::BulletText("Tytan: %d", destroyWynik.sur.second);
                 ImGui::PopStyleColor();
             }
             
@@ -568,7 +568,7 @@ void Graphics::prntBudowanie(const Colony& kolonia,const map<string, BuildingInf
         ImGui::Separator();
         if(ImGui::Button(kategorie[i].c_str())){
                     wybranaKategoriaBudowa=kategorie[i];
-                    czyBudowanieCategory=true;
+                    czyBudowanieCategory=!czyBudowanieCategory;
                 }
         if (ImGui::IsItemHovered()) {
                     ImGui::BeginTooltip(); 
@@ -617,7 +617,7 @@ void Graphics::prntBudowanieWyniki(Game& gra) {
                 ImGui::PopStyleColor();
             } 
             else if (ostatniWynik.act_ruch == 3) {
-\
+
                 ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.0f, 1.0f), "Wykorzystano limit akcji (3/3)!");
                 ImGui::Text("Aby zbudowac kolejny budynek, musisz przejsc do nastepnej rundy.");
             }
@@ -674,7 +674,7 @@ void Graphics::prntBudowanieWyniki(Game& gra) {
         }
     }
     ImGui::End();
-    
+    czyBudowanieCategory=false;
     ImGui::PopStyleColor();
 }
 
@@ -736,7 +736,7 @@ void Graphics::prntBuildCategory(const string& cat, const Colony& kolonia, const
                     
                     ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "Kliknięcie spowoduje zbudowanie tego budynku!");
                     ImGui::Separator();
-                    ImGui::Text("Zbudowanie kosztuje:\n kamień: %d \n tytan: %d", (int)info.kKamien,(int)info.kTytan);
+                    ImGui::Text("Zbudowanie kosztuje:\n kamień: %d \n tytan: %d", info.kKamien,info.kTytan);
                     ImGui::Separator();
                     string opis =info.opis;
                     prntOpis(opis);
@@ -748,14 +748,14 @@ void Graphics::prntBuildCategory(const string& cat, const Colony& kolonia, const
                 if(info.kKamien==0){
                     ImGui::Text("-"); 
                 }else{
-                    ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "-%d", (int)info.kKamien); 
+                    ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "-%d", info.kKamien); 
                 }
                 ImGui::TableNextColumn();
                 
                 if(info.kTytan==0){
                     ImGui::Text("-"); 
                 }else{
-                    ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "-%d", (int)info.kTytan); 
+                    ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "-%d", info.kTytan); 
                 }
                 ImGui::TableNextColumn();
                 if(info.workers==0){
@@ -767,27 +767,27 @@ void Graphics::prntBuildCategory(const string& cat, const Colony& kolonia, const
                 if(info.reqEnergy==0){
                     ImGui::Text("-"); 
                 }else{
-                    ImGui::TextColored(ImVec4(0.2f, 0.8f, 1.0f, 1.0f), "-%d kW", (int)info.reqEnergy);
+                    ImGui::TextColored(ImVec4(0.2f, 0.8f, 1.0f, 1.0f), "-%d kW", info.reqEnergy);
                 }
                 ImGui::TableNextColumn();
                 if(cat=="ENERGY"){
-                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d kW", (int)info.genInne); 
+                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d kW", info.genInne); 
                 }else 
                 if(cat=="HOUSING"){
-                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d miejsc", (int)info.genInne);
+                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d miejsc", info.genInne);
                 }else 
                 if(cat=="FARM"){
-                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d jedzenia", (int)info.genInne);
+                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d jedzenia", info.genInne);
                     ImGui::TableNextColumn();
-                    ImGui::Text("%d tur", (int)info.x);
+                    ImGui::Text("%d tur", info.x);
                 }else 
                 if(cat=="PRODUCER"){
-                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d", (int)info.genKamien);
+                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d", info.genKamien);
                     ImGui::TableNextColumn();
-                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d", (int)info.genTytan);
+                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d", info.genTytan);
                 }else 
                 if(cat=="TERR"){
-                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d", (int)info.genInne);
+                    ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d", info.genInne);
                 }
             }
         }
@@ -892,11 +892,12 @@ void Graphics::prntCzyNextRound(const Colony& kolonia,const map<string, Building
  * @param gra wskaznik do klasy Game
  */
 void Graphics::prntNextRound(const Colony& kolonia, const map<string, BuildingInfo>& bazaDanych, Game& gra) {
-    if (nextWynik.czy) {
+    if (nextWynik.czy && nextWynik.energy && nextWynik.food) {
         ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.2f, 0.6f, 0.2f, 1.0f)); 
     } else {
-        ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.8f, 0.2f, 0.2f, 1.0f)); 
+        ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
     }
+    
 
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
@@ -913,8 +914,7 @@ void Graphics::prntNextRound(const Colony& kolonia, const map<string, BuildingIn
             window.close(); 
         }
     } 
-    else {
-        
+    else {  
         if (!nextWynik.energy) {
             ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.0f, 1.0f), "OSTRZEŻENIE: BLACKOUT!");
             ImGui::Separator();
@@ -925,24 +925,24 @@ void Graphics::prntNextRound(const Colony& kolonia, const map<string, BuildingIn
             ImGui::Separator();
         }
 
-        double zjedzone = kolonia.getReqFood(); 
-        double bilansJedzenia = nextWynik.c_food - zjedzone;
+        int zjedzone = kolonia.getReqFood(); 
+        int bilansJedzenia = nextWynik.c_food - zjedzone;
 
         ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.8f, 1.0f), "Gospodarka żywnościowa:");
         
         
         ImGui::Bullet(); ImGui::Text("Wyprodukowano:");
-        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%.0f", nextWynik.c_food);
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "+%d", nextWynik.c_food);
         
         
         ImGui::Bullet(); ImGui::Text("Zjedzono:");
-        ImGui::SameLine(); ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "-%.0f", zjedzone);
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "-%d", zjedzone);
         
        
         if (bilansJedzenia >= 0) {
-            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "  -> Bilans: +%.0f", bilansJedzenia);
+            ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "  -> Bilans: +%d", bilansJedzenia);
         } else {
-            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "  -> Bilans: %.0f (Zapasy maleją!)", bilansJedzenia);
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "  -> Bilans: %d (Zapasy maleją!)", bilansJedzenia);
         }
 
         ImGui::Dummy(ImVec2(0.0f, 5.0f));
@@ -951,14 +951,14 @@ void Graphics::prntNextRound(const Colony& kolonia, const map<string, BuildingIn
         
         
         ImGui::Bullet(); ImGui::Text("Kamień:");
-        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "+%.0f", nextWynik.c_stone);
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "+%d", nextWynik.c_stone);
         
        
         ImGui::Bullet(); ImGui::Text("Tytan:");
-        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.4f, 0.8f, 1.0f, 1.0f), "+%.0f", nextWynik.c_titan);
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.4f, 0.8f, 1.0f, 1.0f), "+%d", nextWynik.c_titan);
         
         ImGui::Bullet(); ImGui::Text("Terraformacja:");
-        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.9f, 0.3f, 1.0f, 1.0f), "+%.0f", nextWynik.c_terr);
+        ImGui::SameLine(); ImGui::TextColored(ImVec4(0.9f, 0.3f, 1.0f, 1.0f), "+%d", nextWynik.c_terr);
 
         if (nextWynik.terr) {
             ImGui::Dummy(ImVec2(0.0f, 10.0f));

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -38,6 +38,7 @@ class Graphics{
         bool czyNextRound1;
         bool czyWyburzanie;
         bool czyWyburzanie1;
+        
         string wybranaKategoriaBudowa;
         BuildResult ostatniWynik;
         NextResult nextWynik;

--- a/src/housing.cpp
+++ b/src/housing.cpp
@@ -10,7 +10,7 @@ using namespace std;
 // ==========================================
 
 Housing:: Housing():Building("XXX",TypBudynku::HOUSING,0,0,0,0){this->residents=0;}
-Housing::Housing(string n, double kE,double kK, double kT, int r,int w):Building(n,TypBudynku::HOUSING,kE,kK,kT,0){this->residents=r;}
+Housing::Housing(string n, int kE,int kK, int kT, int r,int w):Building(n,TypBudynku::HOUSING,kE,kK,kT,0){this->residents=r;}
 
 // ==========================================
 // OVERRIDE

--- a/src/housing.h
+++ b/src/housing.h
@@ -18,7 +18,7 @@ class Housing: public Building{
     public:
         //KONSTRUKTOR
         Housing();
-        Housing(string n, double kE,double kK, double kT, int r,int w);
+        Housing(string n, int kE,int kK, int kT, int r,int w);
         ~Housing(){};
 
         //OVERRIDE

--- a/src/logistics.cpp
+++ b/src/logistics.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <vector>
 #include <algorithm>
+#include <cmath>
 
 using namespace std;
 
@@ -127,15 +128,15 @@ int Logistics::nextRound(const vector<unique_ptr<Building>>& budynki){
                 cout<<YELLOW<<">>Sprawdzanie produkcji budynkow:..."<<RESET<<endl;
                 cout<<endl;
 
-                double c_food=0;
-                double c_stone=0;
-                double c_titan=0;
-                double c_terr=0;
+                int c_food=0;
+                int c_stone=0;
+                int c_titan=0;
+                int c_terr=0;
                 int new_lvl=0;
 
                 
                 for(const auto& b: budynki){//Przejscie po kazdym zbudowanym budynku
-                    double c=0;
+                    int c=0;
                     c=b->work();//wywolanie funkcji work() na kazdym z budynkow
                     switch(b->getTyp()){//w zaleznosci od klasy, zwrocona wartosc jset przypisywana do czegos innego
                         case TypBudynku::FARM:
@@ -225,15 +226,15 @@ NextResult Logistics::UInextRound(const vector<unique_ptr<Building>>& budynki){
                 // cout<<YELLOW<<">>Sprawdzanie produkcji budynkow:..."<<RESET<<endl;
                 // cout<<endl;
                 
-                double c_food=0;
-                double c_stone=0;
-                double c_titan=0;
-                double c_terr=0;
+                int c_food=0;
+                int c_stone=0;
+                int c_titan=0;
+                int c_terr=0;
                 int new_lvl=0;
 
                 
                 for(const auto& b: budynki){//Przejscie po kazdym zbudowanym budynku
-                    double c=0;
+                    int c=0;
                     c=b->work();//wywolanie funkcji work() na kazdym z budynkow
                     switch(b->getTyp()){//w zaleznosci od klasy, zwrocona wartosc jset przypisywana do czegos innego
                         case TypBudynku::FARM:
@@ -350,7 +351,7 @@ void Logistics::prnt(){
     //Linia 4
     if(food>2*reqFood){
         cout<<GREEN<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<BOLD<<food<<" ("<<reqFood<<")"<<RESET<<endl;
-    }else{if(food>=reqFood & food<2*reqFood){
+    }else{if(food>=reqFood && food<2*reqFood){
         cout<<BLUE<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<BOLD<<food<<" ("<<reqFood<<") "<<NO_BOLD<<RED<<"Starczy tylko na jedna runde!"<<RESET<<endl;
     }else{if(food<reqFood){
     cout<<RED<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<food<<BOLD<<" ("<<reqFood<<")!"<<BOLD<<" Brakuje "<<reqFood-food<<" jedzenia!!!"<<RESET<<endl;
@@ -364,7 +365,7 @@ void Logistics::prnt(){
 }
 
 //WYSWIETLANIE WSZYSTKICH PARAMETROW COLONY PO nextRound, Z ZMIANAMI
-void Logistics::prntRound(double f, double s, double t,double te,int n){
+void Logistics::prntRound(int f, int s, int t,int te,int n){
     
     string sep = YELLOW+" | ";
 
@@ -411,7 +412,7 @@ void Logistics::prntRound(double f, double s, double t,double te,int n){
     if(f!=0){
         if((food+f)>2*reqFood){
             cout<<GREEN<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<BOLD<<food<<CYAN<<" + "<<f<<GREEN<<NO_BOLD<<" ("<<BOLD<<reqFood<<NO_BOLD<<")"<<RESET<<endl;
-        }else{if((food+f)>=reqFood & (food+f)<2*reqFood){
+        }else{if((food+f)>=reqFood && (food+f)<2*reqFood){
             cout<<BLUE<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<BOLD<<food<<CYAN<<" + "<<f<<RED<<NO_BOLD<<" ("<<BOLD<<reqFood<<NO_BOLD<<") "<<RED<<"Starczy tylko na jedna runde!"<<RESET<<endl;
         }else{if((food+f)<reqFood){
         cout<<RED<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<BOLD<<food<<CYAN<<" + "<<f<<NO_BOLD<<RED<<" ("<<BOLD<<reqFood<<NO_BOLD<<")!"<<BOLD<<" Brakuje "<<BOLD<<reqFood+f-food<<NO_BOLD<<" jedzenia!!!"<<RESET<<endl;
@@ -419,7 +420,7 @@ void Logistics::prntRound(double f, double s, double t,double te,int n){
     }else{
         if(food>2*reqFood){
             cout<<GREEN<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<BOLD<<food<<" ("<<reqFood<<")"<<RESET<<endl;
-        }else{if(food>=reqFood & food<2*reqFood){
+        }else{if(food>=reqFood && food<2*reqFood){
             cout<<BLUE<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<BOLD<<food<<" ("<<reqFood<<") "<<NO_BOLD<<RED<<"Starczy tylko na jedna runde!"<<RESET<<endl;
         }else{if(food<reqFood){
         cout<<RED<<"Posiadane jedzenie (zapotrzebowanie na runde): "<<food<<BOLD<<" ("<<reqFood<<")!"<<BOLD<<" Brakuje "<<reqFood-food<<" jedzenia!!!"<<RESET<<endl;
@@ -522,7 +523,7 @@ void Logistics::updateZburzBudynek(Building* budynek){
 }
 
 
-pair<float, float> Logistics::UIupdateZburzBudynek(Building* budynek){
+pair<int, int> Logistics::UIupdateZburzBudynek(Building* budynek){
 
     //Odzyskiwanie pracownikow oraz polowy surowcow
     setDWorkers(-budynek->getDemandWorkers());
@@ -531,8 +532,8 @@ pair<float, float> Logistics::UIupdateZburzBudynek(Building* budynek){
 
     // cout<<YELLOW<<"Odzyskano "<<BOLD<<cleanNum(st/2)<<NO_BOLD<<" kamienia, oraz "<<BOLD<<cleanNum(ti/2)<<NO_BOLD<<" tytanu!"<<RESET<<endl;
     //Odzyskuje sie polowe surowców!
-    titan+=ti/2;
-    stone+=st/2;
+    titan+=(ti-1+2)/2;
+    stone+=(st-1+2)/2;
 
     switch (budynek->getTyp())
     {
@@ -563,7 +564,7 @@ pair<float, float> Logistics::UIupdateZburzBudynek(Building* budynek){
     default:
         break;
     }
-    return {st/2,ti/2};
+    return {(st-1+2)/2,(ti-1+2)/2};
 }
 
 // ==========================================
@@ -588,7 +589,7 @@ void Logistics::load(string nazwa_plik){
     //plik<<nazwa_kolonii<<" "<<tura<<" "<<ruch<<" "<<all_workers<<" "<<demand_workers<<" "<<f_logisyka.getGenEnergy()<<" "<<f_logisyka.getReqEnergy()<<" "<<f_logisyka.getReqFood()<<" "<<f_logisyka.getFood()<<" "<<f_logisyka.getStone()<<" "<<f_logisyka.getTitan()<<endl;
     string nazwa;
     int t,aw,dw,s,ti,r,lt;
-    double ge,re,rf, f,te;
+    int ge,re,rf, f,te;
 
     if (plik.is_open()) {
         plik>>nazwa>>t>>r>>aw>>dw>>te>>lt>>ge>>re>>rf>>f>>s>>ti;
@@ -619,8 +620,8 @@ void Logistics::setTura(){tura++;}
 void Logistics::setRuch(int r){ruch=r;}
 void Logistics::setAWorkers(int aw){all_workers+=aw;}
 void Logistics::setDWorkers(int dw){demand_workers+=dw;}
-void Logistics::setStone(double s){stone=s;}
-void Logistics::setTitan(double t){titan=t;}
+void Logistics::setStone(int s){stone=s;}
+void Logistics::setTitan(int t){titan=t;}
 
 //USTAWIANIE PARAMETROW COLONY - ustawianie testowe - cheaty - daje duza ilosc surowcow
 void Logistics::setSandbox(){
@@ -700,10 +701,10 @@ int Logistics::getRuch() const{return ruch;}
 int Logistics::getAWorkers() const{return all_workers;}
 int Logistics::getDWorkers() const{return demand_workers;};
 
-double Logistics::getReqEnergy() const{return reqEnergy;}
-double Logistics::getGenEnergy() const{return genEnergy;}
-double Logistics::getReqFood() const{return reqFood;}
-double Logistics::getFood() const{return food;}
+int Logistics::getReqEnergy() const{return reqEnergy;}
+int Logistics::getGenEnergy() const{return genEnergy;}
+int Logistics::getReqFood() const{return reqFood;}
+int Logistics::getFood() const{return food;}
 int Logistics::getStone() const{return stone;}
 int Logistics::getTitan() const{return titan;}
 string Logistics::getNazwa() const{return nazwa_kolonii;}

--- a/src/logistics.h
+++ b/src/logistics.h
@@ -22,13 +22,13 @@ class Logistics{
         int all_workers;
         int demand_workers;
         
-        double wsp_terr;
+        int wsp_terr;
         int lvl_terr;
         
-        double reqEnergy;
-        double genEnergy;
-        double reqFood;
-        double food;
+        int reqEnergy;
+        int genEnergy;
+        int reqFood;
+        int food;
         int stone;
         int titan;
 
@@ -41,7 +41,7 @@ class Logistics{
         
         //WYSWIETLANIE
         void prnt();
-        void prntRound(double f, double s, double t, double te,int n);
+        void prntRound(int f, int s, int t, int te,int n);
 
         //NEXT ROUND
         int czyNextRound(const vector<unique_ptr<Building>>& budynki);
@@ -53,7 +53,7 @@ class Logistics{
         //BUDOWANIE
         void updateBudynek(Building* budynek);
         void updateZburzBudynek(Building* budynek);
-        pair<float, float>  UIupdateZburzBudynek(Building* budynek);
+        pair<int, int>  UIupdateZburzBudynek(Building* budynek);
 
         //SAVE/LOAD
         void save(string nazwa_plik);
@@ -65,8 +65,8 @@ class Logistics{
         void setRuch(int r);
         void setAWorkers(int aw);
         void setDWorkers(int dw);
-        void setStone(double s);
-        void setTitan(double t);
+        void setStone(int s);
+        void setTitan(int t);
 
         void setSandbox();
         void setCustom();
@@ -78,10 +78,10 @@ class Logistics{
         int getAWorkers() const;
         int getDWorkers() const;
         
-        double getReqEnergy() const;
-        double getGenEnergy() const;
-        double getReqFood() const;
-        double getFood() const;
+        int getReqEnergy() const;
+        int getGenEnergy() const;
+        int getReqFood() const;
+        int getFood() const;
         int getStone() const;
         int getTitan() const;
         int getLvlTerr() const;

--- a/src/producer.cpp
+++ b/src/producer.cpp
@@ -10,13 +10,13 @@ using namespace std;
 // ==========================================
 
 Producer:: Producer():Building("XXX",TypBudynku::PRODUCER,0,0,0,0),stoneGen(0),titanGen(0){}
-Producer::Producer(string n, double kE,double kK, double kT, double s,int w,double ti):Building(n,TypBudynku::PRODUCER,kE,kK,kT,w),stoneGen(s),titanGen(ti){}
+Producer::Producer(string n, int kE,int kK, int kT, int s,int w,int ti):Building(n,TypBudynku::PRODUCER,kE,kK,kT,w),stoneGen(s),titanGen(ti){}
 
 // ==========================================
 // OVERRIDE
 // ==========================================
 
-double Producer::work(){return stoneGen;}
+int Producer::work(){return stoneGen;}
 
 void Producer::prnt(int il)const{
     prntTablica(name,"Ilosc: ",cleanNum(il),"Koszt energii: ",cleanNum(kosztEnergii),"Pracownicy: ",cleanNum(workers)," "," ","Generowany kamien: ",cleanNum(stoneGen),"Generowany tytan: ",cleanNum(titanGen));
@@ -42,4 +42,4 @@ void Producer::save(ofstream& plik)const{
 // ==========================================
 
 
-double Producer::getGenTitan() const{return titanGen;}
+int Producer::getGenTitan() const{return titanGen;}

--- a/src/producer.h
+++ b/src/producer.h
@@ -15,23 +15,23 @@ using namespace std;
  */
 class Producer: public Building{
     private:
-        double stoneGen;
-        double titanGen;
+        int stoneGen;
+        int titanGen;
 
     public:
         //KONSTRUKTORY
         Producer();
-        Producer(string n, double kE,double kK, double kT, double s,int w,double ti);
+        Producer(string n, int kE,int kK, int kT, int s,int w,int ti);
         ~Producer(){};
 
         //OVERRIDE
-        double work() override;
+        int work() override;
         void prnt(int il) const override;
         void UIprnt(int il) const override;
         void save(ofstream& plik) const override;
 
         //GETTERY
-        double getGenTitan() const;
+        int getGenTitan() const;
 
 
     

--- a/src/terr.cpp
+++ b/src/terr.cpp
@@ -10,13 +10,13 @@ using namespace std;
 // ==========================================
 
 Terr:: Terr():Building("XXX",TypBudynku::TERR,0,0,0,0),terrGen(0){}
-Terr::Terr(string n, double kE,double kK, double kT, double te,int w):Building(n,TypBudynku::TERR,kE,kK,kT,w),terrGen(te){}
+Terr::Terr(string n, int kE,int kK, int kT, int te,int w):Building(n,TypBudynku::TERR,kE,kK,kT,w),terrGen(te){}
 
 // ==========================================
 // OVERRIDE
 // ==========================================
 
-double Terr::work(){return terrGen;}
+int Terr::work(){return terrGen;}
 
 void Terr::prnt(int il)const{
     prntTablica(name,"Ilosc: ",cleanNum(il),"Koszt energii: ",cleanNum(kosztEnergii),"Pracownicy: ",cleanNum(workers),"Wplyw na terraformacje: ",cleanNum(terrGen));
@@ -34,5 +34,5 @@ void Terr::save(ofstream& plik)const{
 // GETTERY
 // ==========================================
 
-double Terr::getTerr() const{return terrGen;}
+int Terr::getTerr() const{return terrGen;}
 

--- a/src/terr.h
+++ b/src/terr.h
@@ -15,23 +15,23 @@ using namespace std;
 class Terr: public Building{
 
     private:
-        double terrGen;
+        int terrGen;
 
     public:
 
         //KONSTRUKTOR
         Terr();
-        Terr(string n, double kE,double kK, double kT, double te,int w);
+        Terr(string n, int kE,int kK, int kT, int te,int w);
         ~Terr(){};
 
         //OVERRIDE
         void prnt(int il) const override;
         void UIprnt(int il) const override;
         void save(ofstream& plik) const override;
-        double work() override;
+        int work() override;
 
         //GETTERY
-        double getTerr() const;
+        int getTerr() const;
 };
 
 #endif


### PR DESCRIPTION
### CHANGED
- Masowa konwersja typów numerycznych: Zmieniono typy bazowe wszystkich zmiennych z `float` / `double` na `int` dla kosztów, produkcji oraz powiązanych liczników w całej bazie kodowej. Zmiana ta wynika z faktu, że w praktyce gra korzysta wyłącznie z wartości całkowitych.
- Aktualizacja klas i struktur: Zmiany objęły składowe klas, konstruktory oraz gettery w modułach: `Building`, `Energy`, `Farm`, `Housing`, `Logistics`, `Colony`, `Enums` oraz `Game`.
- Sygnatury funkcji: Zmodyfikowano wirtualną metodę `work()`, aby zwracała typ `int`. Zaktualizowano również struktury wynikowe (`BuildResult`, `DestroyResult`, `NextResult`), wprowadzając do nich pola całkowite.
- Przetwarzanie zasobów: Dostosowano mechanikę zapisu/odczytu stanu gry, logikę nowej tury oraz systemy budowania i wyburzania do semantyki liczb całkowitych.
- Poprawki w UI (Graphics): Zaktualizowano formatowanie w ImGui (zamiana formatowania na `%d`), dostosowano operacje matematyczne oraz uporządkowano przepływ UI (poprawne pary `PushID`/`PopID` i przełączniki kategorii budowania).

### FIXED
- Logika dzielenia przy zwrotach: Poprawiono obsługę dzielenia całkowitego przy odzyskiwaniu surowców ze zburzonych budynków – zaimplementowano zaokrąglanie w górę (np. operacja $5 / 2$ zwraca teraz poprawnie $3$).
- Błąd logiczny operatora: Naprawiono błąd składniowy w warunku logicznym, zamieniając błędny operator bitowy na logiczny (`&` -> `&&`).